### PR TITLE
sets host to www.ft.com

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ const Delegate = require('ftdomdelegate');
 import { debounce } from 'n-ui-foundations';
 import suggestionList from './src/renderers/search-suggestions';
 
+const host = /local(?:host)?\.ft\.com/.test(window.location.host) ? window.location.host : 'www.ft.com';
+
 function getNonMatcher (container) {
 	if (typeof container === 'string') {
 		return function (el) {
@@ -33,7 +35,7 @@ class TopicSearch {
 		this.listComponent = listComponent;
 		this.preSuggest = preSuggest;
 		this.searchEl = this.container.querySelector('[data-n-topic-search-input]');
-		this.dataSrc = `//${window.location.host}/search-api/suggestions?partial=`;
+		this.dataSrc = `//${host}/search-api/suggestions?partial=`;
 		this.categories = (this.container.getAttribute('data-n-topic-search-categories') || 'tags').split(',');
 		this.itemTag = this.container.getAttribute('data-n-topic-search-item-tag') || 'a';
 		this.includeViewAllLink = this.container.hasAttribute('data-n-topic-search-view-all');


### PR DESCRIPTION
To fix console errors when using search on the ft.com error page. 

Raised by Tanya in the support channel and previously fixed in n-ui here: https://github.com/Financial-Times/n-ui/pull/1083/files