### PR TITLE
Replace ft.yml with CODEOWNERS file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ references:
 
   npm_cache_keys: &npm_cache_keys
     keys:
-        - v1-dependency-npm-{{ checksum "package.json" }}-
-        - v1-dependency-npm-{{ checksum "package.json" }}
-        - v1-dependency-npm-
+        - v2-dependency-npm-{{ checksum "package.json" }}-
+        - v2-dependency-npm-{{ checksum "package.json" }}
+        - v2-dependency-npm-
 
   cache_npm_cache: &cache_npm_cache
     save_cache:
-        key: v1-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
+        key: v2-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
         paths:
         - ./node_modules/
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# See https://help.github.com/articles/about-codeowners/ for more information about this file.
+
+* matt.hinchliffe@ft.com

--- a/ft.yml
+++ b/ft.yml
@@ -1,3 +1,0 @@
-owner:
-  github: i-like-robots
-  email: matt.hinchliffe@ft.com

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {
-    "@financial-times/n-gage": "^1.8.18",
+    "@financial-times/n-gage": "3.4.0",
     "@financial-times/n-internal-tool": "^2.0.0",
     "bower": "^1.8.0",
     "bower-resolve-webpack-plugin": "^1.0.3",


### PR DESCRIPTION
This PR replaces our custom `ft.yml` file with GitHub's standard CODEOWNERS file. The CODEOWNERS file defines the individual or team that is responsible for the code in the repository. Unlike `ft.yml`, code owners will automatically be asked to review any pull requests.

For more information on CODEOWNERS, see https://help.github.com/en/articles/about-code-owners.

Where a repository contains an empty `ft.yml`, no CODEOWNERS file will be created. We did this so we can easily identify which repositories are unowned by looking for the absence of a CODEOWNERS file.

The n-gage package insists that repositories have an ft.yml file. Version 3.4.0 of n-gage removes this requirement. This transformation requires n-gage version 3.4.0 in package.json because it deletes the (otherwise required) ft.yml file.
