### PR TITLE
DAC: Announce when search results have been displayed

### DIFF
--- a/src/renderers/search-suggestions.js
+++ b/src/renderers/search-suggestions.js
@@ -110,7 +110,7 @@ class SuggestionList extends BaseRenderer {
 			${ hasSuggestions ? `<div
 				aria-live="assertive"
 				class="o-normalise-visually-hidden">
-				Search results have been displayed. These will update automatically as you change your search term.
+				Search results have been displayed. To jump to the list of suggestions press tab.
 			</div>` : '' }
 			<div
 				class="n-topic-search"

--- a/src/renderers/search-suggestions.js
+++ b/src/renderers/search-suggestions.js
@@ -106,7 +106,13 @@ class SuggestionList extends BaseRenderer {
 				}
 			});
 		}
-		this.newHtml = `<div
+		this.newHtml = `
+			${ hasSuggestions ? `<div
+				aria-live="assertive"
+				class="o-normalise-visually-hidden">
+				Search results have been displayed. These will update automatically as you change your search term.
+			</div>` : '' }
+			<div
 				class="n-topic-search"
 				${ hasSuggestions ? '' : 'hidden'}
 				data-trackable="typeahead"


### PR DESCRIPTION
https://trello.com/c/0vDrIL2R/107-dacstatusmessagenotannouncedissue1

### From DAC

Comments:
> On searching in 'Search the FT' edit field the suggestions appears automatically an
announcement should be made for screen reader user from which user would be able to
know about suggestions. 

Solution:
> Provide a visually hidden `<div>` with `aria-live="assertive"` and put some information text
into visually hidden `<div>` to make an announcement.