### PR TITLE
Fix broken search

### DIFF
--- a/src/renderers/search-suggestions.js
+++ b/src/renderers/search-suggestions.js
@@ -106,19 +106,19 @@ class SuggestionList extends BaseRenderer {
 				}
 			});
 		}
-		this.newHtml = `
-			${ hasSuggestions ? `<div
-				aria-live="assertive"
-				class="o-normalise-visually-hidden">
-				Search results have been displayed. To jump to the list of suggestions press tab.
-			</div>` : '' }
-			<div
+		this.newHtml = `<div
 				class="n-topic-search"
 				${ hasSuggestions ? '' : 'hidden'}
 				data-trackable="typeahead"
 			>
 				${ suggestions.map(this.renderSuggestionGroup).join('') }
-			</div>`;
+			</div>
+			${ hasSuggestions ? `<div
+				aria-live="assertive"
+				class="o-normalise-visually-hidden">
+				Search results have been displayed. To jump to the list of suggestions press tab.
+			</div>` : '' }
+			`;
 	}
 
 	handleSelection (el, ev) {


### PR DESCRIPTION
### Problem
If you change your search term, the results are not updated. You need to refresh the page in order to search for something else.


### Cause
This was caused by [my accessibility fix](https://github.com/Financial-Times/n-topic-search/pull/22). The [base renderer](https://github.com/Financial-Times/n-topic-search/blob/master/src/renderers/base-renderer.js#L37) relies on a specific DOM structure + the screen reader message changed that structure. This fix moves the message to _the least likely to break anything position_, but longer term there might some changes to rendering to make it more robust.



