### PR TITLE
Move dependency from bower to package.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,6 @@
     "tests"
   ],
   "dependencies": {
-    "morphdom": "^2.3.2",
     "n-ui-foundations": "^3.0.0-beta"
   },
   "description": "",

--- a/bower.json
+++ b/bower.json
@@ -2,18 +2,11 @@
   "name": "n-topic-search",
   "version": "0.0.0",
   "homepage": "https://github.com/Financial-Times/n-topic-search",
-  "authors": [
-    "Rhys Evans <wheresrhys@gmail.com>"
-  ],
+  "authors": ["Rhys Evans <wheresrhys@gmail.com>"],
   "license": "MIT",
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "test",
-    "tests"
-  ],
+  "ignore": ["**/.*", "node_modules", "bower_components", "test", "tests"],
   "dependencies": {
+    "morphdom": "^2.3.2",
     "n-ui-foundations": "^3.0.0-beta"
   },
   "description": "",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "morphdom": "^2.5.4"
+  },
   "devDependencies": {
     "@financial-times/n-gage": "^3.6.0",
     "@financial-times/n-internal-tool": "^2.0.0",


### PR DESCRIPTION
When adding `n-topic-search` as a `package.json` dependancy, it requires the addition of `morphdom`. The project I'm integrating with this does not have `bower`, and thus cannot pick it up from there.