### PR TITLE
Announce search suggestions in screen readers

### DIFF
--- a/src/renderers/base-renderer.js
+++ b/src/renderers/base-renderer.js
@@ -31,10 +31,19 @@ export default class BaseRenderer {
 
 	render () {
 		if (this.container.innerHTML.trim()) {
+			// empty the suggestions div first to prevent
+			// screen readers reading the old suggestions
+			const empty = document.createElement('div');
+			const suggestions = this.container.querySelector('.n-topic-search__suggestions');
+			if (suggestions) {
+				morphdom(suggestions, empty);
+			}
+
 			const frag = document.createDocumentFragment();
 			frag.appendChild(document.createElement('div'));
 			frag.firstChild.insertAdjacentHTML('beforeend', this.newHtml);
-			morphdom(this.container.firstChild, frag.firstChild.firstChild);
+
+			morphdom(this.container.firstChild, frag.firstChild);
 		} else {
 			this.container.innerHTML = this.newHtml;
 		}

--- a/src/renderers/search-suggestions.js
+++ b/src/renderers/search-suggestions.js
@@ -106,19 +106,21 @@ class SuggestionList extends BaseRenderer {
 				}
 			});
 		}
-		this.newHtml = `<div
-				class="n-topic-search"
-				${ hasSuggestions ? '' : 'hidden'}
-				data-trackable="typeahead"
-				aria-live="assertive"
-			>
-				${ suggestions.map(this.renderSuggestionGroup).join('') }
+		this.newHtml = `
+			<div aria-live="assertive">
+				${ hasSuggestions ? `<div
+					class="o-normalise-visually-hidden n-topic-search__suggestions_explanation">
+					Search results have been displayed. To jump to the list of suggestions press the down arrow key.
+				</div>` : '' }
+				<div
+					class="n-topic-search n-topic-search__suggestions"
+					${ hasSuggestions ? '' : 'hidden'}
+					data-trackable="typeahead"
+				>
+					<div class="o-normalise-visually-hidden">Suggestions include</div>
+					${ suggestions.map(this.renderSuggestionGroup).join('') }
+				</div>
 			</div>
-			${ hasSuggestions ? `<div
-				aria-live="assertive"
-				class="o-normalise-visually-hidden">
-				Search results have been displayed. To jump to the list of suggestions press the down arrow key.
-			</div>` : '' }
 			`;
 	}
 

--- a/src/renderers/search-suggestions.js
+++ b/src/renderers/search-suggestions.js
@@ -110,6 +110,7 @@ class SuggestionList extends BaseRenderer {
 				class="n-topic-search"
 				${ hasSuggestions ? '' : 'hidden'}
 				data-trackable="typeahead"
+				aria-live="assertive"
 			>
 				${ suggestions.map(this.renderSuggestionGroup).join('') }
 			</div>

--- a/src/renderers/topic-search.js
+++ b/src/renderers/topic-search.js
@@ -32,13 +32,13 @@ class TopicSearch extends BaseRenderer {
 			${ hasSuggestions ? '' : 'hidden'}
 			data-trackable="typeahead">
 			${ suggestions.map(suggestion =>
-					`<li class="n-topic-search__item">
+		`<li class="n-topic-search__item">
 						<button type="button" class="n-topic-search__target search-filtering__suggestion"
 							data-trackable="concept-suggestion"
 							data-suggestion-id="${suggestion.id}"
 							data-suggestion-name="${suggestion.prefLabel}">${suggestion.html}</button>
 					</li>`
-				).join('') }
+	).join('') }
 		</ul>`;
 	}
 }


### PR DESCRIPTION
Addresses [DAC_Status_message_not_announced_Issue1](https://trello-attachments.s3.amazonaws.com/5aaa39b3d9fed818bd80c809/5aabd4eb3100714dabbeaabc/c61472793b3ddb07899a166b986c7fb8/Financial_Times_-_8_August_2019_-_Accessibility_Audit_Retest.pdf#page=31)


DAC test suggests that the screen readers should announce the automatic search suggestions.
