### PR TITLE
Update n-ui-foundation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "ignore": ["**/.*", "node_modules", "bower_components", "test", "tests"],
   "dependencies": {
     "morphdom": "^2.5.10",
-    "n-ui-foundations": "^4.0.0-beta.2"
+    "n-ui-foundations": "^6.0.0"
   },
   "description": "",
   "main": ""

--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ let defaultHostName = 'www.ft.com';
 
 // Check if developing locally, if we are then proxy the search api through
 // the demo application.
-const hostname = window.location.hostname
+const hostname = window.location.hostname;
 if (hostname === 'localhost' || hostname === 'local.ft.com') {
-	defaultHostName = window.location.host
+	defaultHostName = window.location.host;
 }
 
 function getNonMatcher (container) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,14 @@ import Delegate from 'ftdomdelegate';
 import { debounce } from 'n-ui-foundations';
 import suggestionList from './src/renderers/search-suggestions';
 
-const defaultHostName = /local(?:host)?\.ft\.com/.test(window.location.host) ? window.location.host : 'www.ft.com';
+let defaultHostName = 'www.ft.com';
+
+// Check if developing locally, if we are then proxy the search api through
+// the demo application.
+const hostname = window.location.hostname
+if (hostname === 'localhost' || hostname === 'local.ft.com') {
+	defaultHostName = window.location.host
+}
 
 function getNonMatcher (container) {
 	if (typeof container === 'string') {


### PR DESCRIPTION
Looking at this component it does not seem to reference the [snappy grid mixins or classes](https://github.com/Financial-Times/n-ui-foundations/commit/d477970578cdb623099096ac73dfc47a5c8b1fc3) or [font weights](https://github.com/Financial-Times/n-ui-foundations/releases/tag/v5.0.0).

So seems ok to upgrade `n-ui-foundation` to version 6.0.0, I've managed to get it running locally with a change to the development logic.

<img width="362" alt="" src="https://user-images.githubusercontent.com/2445413/84907106-b4a71880-b0aa-11ea-91fb-d58cf9a00cb6.png">
<img width="1129" alt="" src="https://user-images.githubusercontent.com/2445413/84907109-b670dc00-b0aa-11ea-8e08-de6df2983a1b.png">
