### PR TITLE
Switch to new NPM publish token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,46 +2,55 @@
 # template: component
 
 references:
-  container_config: &container_config
+  container_config:
+    &container_config
     working_directory: ~/project/build
     docker:
       - image: circleci/node:12-browsers
 
   workspace_root: &workspace_root ~/project
 
-  attach_workspace: &attach_workspace
+  attach_workspace:
+    &attach_workspace
     attach_workspace:
       at: *workspace_root
 
-  npm_cache_keys: &npm_cache_keys
+  npm_cache_keys:
+    &npm_cache_keys
     keys:
-        - v3-dependency-npm-{{ checksum "package-lock.json" }}-
-        - v3-dependency-npm-{{ checksum "package-lock.json" }}
-        - v3-dependency-npm-
+      - v3-dependency-npm-{{ checksum "package-lock.json" }}-
+      - v3-dependency-npm-{{ checksum "package-lock.json" }}
+      - v3-dependency-npm-
 
-  cache_npm_cache: &cache_npm_cache
+  cache_npm_cache:
+    &cache_npm_cache
     save_cache:
-        key: v3-dependency-npm-{{ checksum "package-lock.json" }}-{{ epoch }}
-        paths:
+      key: v3-dependency-npm-{{ checksum "package-lock.json" }}-{{ epoch }}
+      paths:
         - ./node_modules/
 
-  restore_npm_cache: &restore_npm_cache
+  restore_npm_cache:
+    &restore_npm_cache
     restore_cache:
       <<: *npm_cache_keys
 
-  filters_only_main: &filters_only_main
+  filters_only_main:
+    &filters_only_main
     branches:
       only: main
 
-  filters_ignore_main: &filters_ignore_main
+  filters_ignore_main:
+    &filters_ignore_main
     branches:
       ignore: main
 
-  filters_ignore_tags: &filters_ignore_tags
+  filters_ignore_tags:
+    &filters_ignore_tags
     tags:
       ignore: /.*/
 
-  filters_version_tag: &filters_version_tag
+  filters_version_tag:
+    &filters_version_tag
     tags:
       only:
         - /^v?\d+\.\d+\.\d+(?:-beta\.\d+)?$/
@@ -60,7 +69,9 @@ jobs:
       - checkout
       - run:
           name: Checkout next-ci-shared-helpers
-          command: git clone --depth 1 git@github.com:Financial-Times/next-ci-shared-helpers.git .circleci/shared-helpers
+          command: git clone --depth 1
+            git@github.com:Financial-Times/next-ci-shared-helpers.git
+            .circleci/shared-helpers
       - *restore_npm_cache
       - node/install-npm:
           version: "7"
@@ -109,7 +120,8 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
-      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/n-topic-search
+      - run: npx snyk monitor --org=customer-products
+          --project-name=Financial-Times/n-topic-search
       - run:
           name: shared-helper / npm-version-and-publish-public
           command: .circleci/shared-helpers/helper-npm-version-and-publish-public
@@ -137,6 +149,7 @@ workflows:
           requires:
             - build
       - publish:
+          context: npm-publish-token
           filters:
             <<: *filters_version_tag
           requires:


### PR DESCRIPTION
Why?
We're in the process of looking at making our NPM publish process more secure. As part of that, we want to migrate our existing NPM publish jobs to use a new publish token, then revoke all of the old tokens.

@wheresrhys suggested using this package as a test to check that it works - for more info on the overall plan, see [this draft doc](https://docs.google.com/document/d/1xnUfCgUVvfotBSWFVD1ajpVy9qhnTc8qfFvkY6fN5Gg/edit#).

What?
Use the NPM_AUTH_TOKEN variable within the npm-publish-token context.