### PR TITLE
Use input vs keyup for search requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,12 +87,10 @@ class TopicSearch {
 				case 40 :
 					this.onDownArrow(ev);
 					break;
-				default :
-					this.onType(ev);
-					break;
 			}
 		});
 
+		this.searchEl.addEventListener('input', this.onType);
 		this.searchEl.addEventListener('focus', this.onFocus);
 		this.searchEl.addEventListener('click', this.onFocus);
 


### PR DESCRIPTION
Currently, any key event that isn't enter, tab, escape, or the down arrow; will trigger a new request to the next-search-api. This is because we use the `keyup` event to trigger these requests.

E.g., if a user types a search query, notices a typo, then uses the arrow keys to navigate to it and fix it, each arrow key press will prompt a new search request (not accounting for debounce). If a user hits shift, control, meta, or any other non-character key, this will also trigger a next-search-api request!

This PR changes this logic, to instead use the `input` event, which only fires when the textbox's content has changed. This is in an effort to reduce unnecessary traffic to the next-search-api.

On top of this, my team (professional lifecycle experience), are about to release an 'enhanced' version of the current search bar, which uses n-topic-search, just as the current search bar does. It also adds a loading spinner for its results. At the moment, this loading spinner is appearing much more than we'd like it to, because of the issue that this PR fixes!
