### PR TITLE
Remove deprecated Sass division

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -75,7 +75,7 @@
 		box-sizing: border-box;
 		display: block;
 		text-decoration: none;
-		padding: $spacing-unit/2 $spacing-unit;
+		padding: $spacing-unit*0.5 $spacing-unit;
 		display: block;
 		background: none;
 		border: 0;


### PR DESCRIPTION
Sass currently treats / as a division operation in some contexts and a separator in others. This makes it difficult for Sass users to tell what any given / will mean, and makes it hard to work with new CSS features that use / as a separator. It will be removed in a future version of Sass.
https://sass-lang.com/documentation/breaking-changes/slash-div/

As such it is causing annoying warnings for all projects which include this project.

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($spacing-unit, 2) or calc($spacing-unit / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
78 │         padding: $spacing-unit/2 $spacing-unit;
   │                  ^^^^^^^^^^^^^^^
   ╵
    node_modules/@financial-times/dotcom-ui-header/node_modules/n-topic-search/main.scss 78:12  nTopicSearch()
    node_modules/@financial-times/dotcom-ui-header/styles.scss 14:1                             @import
    stdin 49:9                                                                                  root stylesheet
```

Instead we can:

1. Use a plain CSS `calc` funciton
2. Use multiplication
3. Use `math.div`

```scss
@use "sass:math";

// WRONG, will not work in future Sass versions.
@debug (12px/4px); // 3

// RIGHT, will work in future Sass versions.
@debug math.div(12px, 4px); // 3
```

In this case I went for option 2, because that's what the Sass migrator did for me: https://sass-lang.com/documentation/cli/migrator/

```
sass-migrator division  main.scss --load-path node_modules/
```

But really, I'd advocate 1 (plain CSS) in the future :D https://origami.ft.com/blog/2024/01/24/sass-build-times/